### PR TITLE
[FIXTURE] Document ha_call_service parameters

### DIFF
--- a/workflow-fixtures/pull-requests/source-pr-2327.md
+++ b/workflow-fixtures/pull-requests/source-pr-2327.md
@@ -1,0 +1,11 @@
+# Source PR 2327 — service parameter documentation
+
+Source: https://github.com/homeassistant-ai/ha-mcp/pull/2327
+
+This fixture represents a focused documentation-only change adding
+`Annotated[..., Field(description=...)]` metadata to six `ha_call_service`
+parameters. The source PR changes two files, adds 92 lines, deletes 11, has a
+requested-changes review, and currently has one failing fast-check lane.
+
+The contributor reports syntax validation and an external schema inspection,
+but could not run the Python 3.13 test suite locally.


### PR DESCRIPTION
Source scenario: https://github.com/homeassistant-ai/ha-mcp/pull/2327

Focused documentation-only fixture. The proposed change adds parameter descriptions to `ha_call_service`. The source PR is blocked by requested changes and a failing fast check; the contributor could not run the full Python 3.13 suite locally.

This PR exists only for Codex workflow evaluation.

<!-- workflow-fixture:fixture-66 -->

— Cocobot, AI agent maintaining test fixtures for Julien.