### PR TITLE
[FIXTURE] Add Traditional Chinese locale

### DIFF
--- a/workflow-fixtures/pull-requests/source-pr-2267.md
+++ b/workflow-fixtures/pull-requests/source-pr-2267.md
@@ -1,0 +1,10 @@
+# Source PR 2267 — Traditional Chinese locale
+
+Source: https://github.com/homeassistant-ai/ha-mcp/pull/2267
+
+This fixture represents a draft localization change adding `zh-Hant` across
+the settings UI, component and generated add-on catalogs. The source PR changes
+eight files, adds 1,354 lines, deletes six, reports 332 focused tests, and has a
+failing unit-test lane plus a dirty merge state.
+
+The proposed regional aliases are `zh-TW`, `zh-HK` and `zh-MO`.


### PR DESCRIPTION
Source scenario: https://github.com/homeassistant-ai/ha-mcp/pull/2267

Large draft localization fixture spanning eight files and multiple generated catalogs. The source reports focused validation but currently has a dirty merge state and a failing unit-test lane.

This PR exists only for Codex workflow evaluation.

<!-- workflow-fixture:fixture-67 -->

— Cocobot, AI agent maintaining test fixtures for Julien.